### PR TITLE
SSO without 2FA + UPN as Identity fixed

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -86,12 +86,11 @@ namespace MultiFactor.SelfService.Windows.Portal.Controllers
             // credential is VALID
             if (adValidationResult.IsAuthenticated)
             {
+                var identity = GetIdentity(model, adValidationResult);
                 if (sso.HasSamlSession() && adValidationResult.IsBypass)
                 {
-                    return ByPassSamlSession(model.UserName, sso.SamlSessionId);
+                    return ByPassSamlSession(identity, sso.SamlSessionId);
                 }
-
-                var identity = GetIdentity(model, adValidationResult);
                 return RedirectToMfa(identity, model.MyUrl, sso.SamlSessionId, sso.OidcSessionId, adValidationResult);
             }
 

--- a/Services/ActiveDirectoryCredentialValidationResult.cs
+++ b/Services/ActiveDirectoryCredentialValidationResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using MultiFactor.SelfService.Windows.Portal.Services.Ldap;
+using System.Text.RegularExpressions;
 
 namespace MultiFactor.SelfService.Windows.Portal.Services
 {
@@ -78,6 +79,26 @@ namespace MultiFactor.SelfService.Windows.Portal.Services
         public static ActiveDirectoryCredentialValidationResult UnknowError(string errorMessage = null)
         {
             return new ActiveDirectoryCredentialValidationResult { Reason = errorMessage ?? "Unknown error"};
+        }
+    }
+
+    public static class ActiveDirectoryValidationResultHelper
+    {
+        public static ActiveDirectoryCredentialValidationResult Fill(this ActiveDirectoryCredentialValidationResult result, LdapProfile profile, Configuration configuration)
+        {
+            result.DisplayName = profile.DisplayName;
+            result.Email = profile.Email;
+            result.Upn = profile.Upn;
+
+            if (configuration.UseActiveDirectoryUserPhone)
+            {
+                result.Phone = profile.Phone;
+            }
+            if (configuration.UseActiveDirectoryMobileUserPhone)
+            {
+                result.Phone = profile.Mobile;
+            }
+            return result;
         }
     }
 }

--- a/Services/ActiveDirectoryService.cs
+++ b/Services/ActiveDirectoryService.cs
@@ -96,27 +96,14 @@ namespace MultiFactor.SelfService.Windows.Portal.Services
                         {
                             _logger.Information($"User '{{user:l}}' is not member of {_configuration.ActiveDirectory2FaGroup} group", user.Name);
                             _logger.Information("Bypass second factor for user '{user:l}'", user.Name);
-                            return ActiveDirectoryCredentialValidationResult.ByPass();
+                            return ActiveDirectoryCredentialValidationResult.ByPass()
+                                .Fill(profile, _configuration);
                         }
                         _logger.Information($"User '{{user:l}}' is member of {_configuration.ActiveDirectory2FaGroup} group", user.Name);
                     }
 
-                    var result = ActiveDirectoryCredentialValidationResult.Ok();
-                    
-                    result.DisplayName = profile.DisplayName;
-                    result.Email = profile.Email;
-                    result.Upn = profile.Upn;
-
-                    if (_configuration.UseActiveDirectoryUserPhone)
-                    {
-                        result.Phone = profile.Phone;
-                    }
-                    if (_configuration.UseActiveDirectoryMobileUserPhone)
-                    {
-                        result.Phone = profile.Mobile;
-                    }
-
-                    return result;
+                    return ActiveDirectoryCredentialValidationResult.Ok()
+                        .Fill(profile, _configuration);
                 }
             }
             catch (LdapException lex)


### PR DESCRIPTION
### Release 25.07.2023 | SSO Login takes into account the "UPN as Identity" flag now.
#### Bugfixes
- Fixed: Identity calculation during SSO in case a second factor bypassed.