### PR TITLE
link showcase added

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MultiFactor.SelfService.Windows.Portal.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Configuration;
@@ -132,7 +133,7 @@ namespace MultiFactor.SelfService.Windows.Portal
 
         public TimeSpan? PwdChangingSessionLifetime { get; private set; }
         public long? PwdChangingSessionCacheSize { get; private set; }
-
+        public List<Link> Links { get; private set; }
         public static void Load()
         {
             var appSettings = PortalSettings;
@@ -196,6 +197,12 @@ namespace MultiFactor.SelfService.Windows.Portal
                 configuration.RequiresUpn = activeDirectorySection.RequiresUpn;
             }
 
+            var linkShowcaseSection = (LinkShowcaseSection)ConfigurationManager.GetSection("linksShowcase");
+            if (linkShowcaseSection != null)
+            {
+                configuration.Links = (from object value in linkShowcaseSection.Links
+                                      select new Link((LinkElement)value)).ToList();
+            }
 
             if (!string.IsNullOrEmpty(appSettings[ConfigurationConstants.ObsoleteCaptcha.ENABLE_GOOGLE_RECAPTCHA]))
             {
@@ -461,6 +468,52 @@ namespace MultiFactor.SelfService.Windows.Portal
             get { return (bool)this["requiresUserPrincipalName"]; }
         }
     }
+
+    public class LinkShowcaseSection : ConfigurationSection
+    {
+        [ConfigurationProperty("", IsDefaultCollection = true)]
+        public LinkShowcaseElementCollection Links
+        {
+            get { return (LinkShowcaseElementCollection)this[""]; }
+        }
+    }
+
+
+    public class LinkShowcaseElementCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new LinkElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return (element as LinkElement).Url;
+        }
+
+        public override ConfigurationElementCollectionType CollectionType
+        {
+            get { return ConfigurationElementCollectionType.BasicMap; }
+        }
+
+        protected override string ElementName
+        {
+            get { return "link"; }
+        }
+    }
+
+    public class LinkElement : ConfigurationElement
+    {
+        [ConfigurationProperty("url", IsRequired = true, IsKey = true)]
+        public string Url { get { return (string)this["url"]; } }
+
+        [ConfigurationProperty("title", IsRequired = true)]
+        public string Title { get { return (string)this["title"]; } }
+
+        [ConfigurationProperty("image", IsRequired = true)]
+        public string Image { get { return (string)this["image"]; } }
+    }
+
 
     public enum RequireCaptcha
     {

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -133,7 +133,7 @@ namespace MultiFactor.SelfService.Windows.Portal
 
         public TimeSpan? PwdChangingSessionLifetime { get; private set; }
         public long? PwdChangingSessionCacheSize { get; private set; }
-        public List<Link> Links { get; private set; }
+        public Link[] Links { get; private set; }
         public static void Load()
         {
             var appSettings = PortalSettings;
@@ -201,7 +201,7 @@ namespace MultiFactor.SelfService.Windows.Portal
             if (linkShowcaseSection != null)
             {
                 configuration.Links = (from object value in linkShowcaseSection.Links
-                                      select new Link((LinkElement)value)).ToList();
+                                      select new Link((LinkElement)value)).ToArray();
             }
 
             if (!string.IsNullOrEmpty(appSettings[ConfigurationConstants.ObsoleteCaptcha.ENABLE_GOOGLE_RECAPTCHA]))

--- a/Content/style/site.css
+++ b/Content/style/site.css
@@ -500,6 +500,7 @@ p {
     -ms-flex-direction: column;
     flex-direction: column;
     padding-top: 20px;
+    padding-bottom: 20px;
 }
 
 #main {
@@ -866,6 +867,7 @@ table.authenticators {
     justify-content: center;
     align-items: center;
     padding: 16px;
+    margin-top: -7vh;
 }
 
 .showcase-link {

--- a/Content/style/site.css
+++ b/Content/style/site.css
@@ -857,3 +857,31 @@ table.authenticators {
             transform: translateY(-50%);
         }
 }
+
+
+.showcase {
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 32px;
+    justify-content: center;
+    align-items: center;
+    padding: 16px;
+}
+
+.showcase-link {
+    display: flex;
+    flex-flow: column nowrap;
+    gap: 8px;
+    padding: 1rem 2rem;
+    justify-content: center;
+    align-items: center;
+}
+
+.showcase-link:hover {
+    border: 1px solid #4082BC;
+    border-radius: 4px;
+}
+.showcase-link-image {
+    height: 64px;
+    width: 64px;
+}

--- a/Models/Link.cs
+++ b/Models/Link.cs
@@ -1,0 +1,17 @@
+﻿
+namespace MultiFactor.SelfService.Windows.Portal.Models
+{
+    public class Link
+    {
+        public Link(LinkElement linkElement) 
+        {
+            Url = linkElement.Url;
+            Title = linkElement.Title;
+            Image = linkElement.Image;
+        }
+
+        public string Url { get; set; }
+        public string Title { get; set; }
+        public string Image { get; set; }
+    }
+}

--- a/MultiFactor.SelfService.Windows.Portal.csproj
+++ b/MultiFactor.SelfService.Windows.Portal.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Models\ChangeExpiredPasswordModel.cs" />
     <Compile Include="Models\ChangePasswordModel.cs" />
     <Compile Include="Models\GoogleAuthenticatorModel.cs" />
+    <Compile Include="Models\Link.cs" />
     <Compile Include="Models\LoginModel.cs" />
     <Compile Include="Models\PasswordRecovery\ConfirmPasswordRecoveryForm.cs" />
     <Compile Include="Models\PasswordRecovery\EnterIdentityForm.cs" />

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -10,6 +10,24 @@
 
 <div class="block">
     <div class="container">
+        @if (Configuration.Current.Links != null && Configuration.Current.Links.Count > 0)
+        {
+            <div class="showcase">
+                @foreach (var link in Configuration.Current.Links)
+                {
+                    <a href="@link.Url">
+                        <div class="showcase-link">
+                            <img class="showcase-link-image" src="~/content/images/@link.Image" />
+
+                            <div class="link-title">
+                                @link.Title
+                            </div>
+                        </div>
+                    </a>
+                }
+            </div>
+        }
+
         <p>@Resources.Home.Greetings @(Model.Name ?? Model.Identity).</p>
         <p>@Resources.Home.ConfiguredMethods</p>
         <table class="authenticators max600">

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 
 <div class="block">
     <div class="container">
-        @if (Configuration.Current.Links != null && Configuration.Current.Links.Count > 0)
+        @if (Configuration.Current.Links != null && Configuration.Current.Links.Length > 0)
         {
             <div class="showcase">
                 @foreach (var link in Configuration.Current.Links)

--- a/Web.config
+++ b/Web.config
@@ -7,6 +7,7 @@
   <configSections>
     <section name="portalSettings" type="System.Configuration.AppSettingsSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
     <section name="ActiveDirectory" type="MultiFactor.SelfService.Windows.Portal.ActiveDirectorySection, MultiFactor.SelfService.Windows.Portal"/>
+    <section name="linksShowcase" type="MultiFactor.SelfService.Windows.Portal.LinkShowcaseSection" />
   </configSections>
   <portalSettings>
     <!--Company Name-->
@@ -61,6 +62,19 @@
     -->
     <!--<add key="sign-up-groups" value="pass"/>-->
   </portalSettings>
+  <!--
+        Use the following section to describe a link showcase on the portal.
+        You can specify a list of links and they will be displayed at the home page.
+        link have three required properties:
+        1. url: please specify an URL where the link should target;
+        2. title: an arbitrary string;
+        3. image: place an image into site's Content/images/ folder and write down it's name.
+  -->
+  <!--
+  <linksShowcase>
+     <link url="http://multifactor.ru" title="multifactor" image="logo.svg"/>
+  </linksShowcase>
+  -->
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0"/>
     <add key="webpages:Enabled" value="false"/>


### PR DESCRIPTION
###  Links Showcase Panel
#### New
- Links Showcase Panel was added.  Now you can define URLs to be presented on the main page of your  self-service portal instance.
  Use the following section to describe a link showcase on the portal:
   ```xml
    <linksShowcase>
       <link url="http://multifactor.ru" title="multifactor" image="logo.svg"/>
    </linksShowcase>
    ```
  A link entry have three required properties:
  1. url: please specify an URL where the link should target;
  2. title: an arbitrary string;
  3. image: place an image into site's Content/images/ folder and write down it's name.
