### PR TITLE
Add a showcase link attribute to open a link in new tab

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -532,6 +532,15 @@ namespace MultiFactor.SelfService.Windows.Portal
 
         [ConfigurationProperty("image", IsRequired = true)]
         public string Image { get { return (string)this["image"]; } }
+
+        [ConfigurationProperty("newTab", IsRequired = false, DefaultValue = true)]
+        public bool OpenInNewTab 
+        {
+            get
+            {
+                return (bool)this["newTab"]; 
+            }
+        }
     }
 
 

--- a/Models/Link.cs
+++ b/Models/Link.cs
@@ -8,10 +8,12 @@ namespace MultiFactor.SelfService.Windows.Portal.Models
             Url = linkElement.Url;
             Title = linkElement.Title;
             Image = linkElement.Image;
+            OpenInNewTab = linkElement.OpenInNewTab;
         }
 
         public string Url { get; set; }
         public string Title { get; set; }
         public string Image { get; set; }
+        public bool OpenInNewTab { get; set; }
     }
 }

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -15,7 +15,7 @@
             <div class="showcase">
                 @foreach (var link in Configuration.Current.Links)
                 {
-                    <a href="@link.Url">
+                    <a href="@link.Url" @(link.OpenInNewTab ? "target=_blank" : "")>
                         <div class="showcase-link">
                             <img class="showcase-link-image" src="~/content/images/@link.Image" />
 


### PR DESCRIPTION
### Release 26.04.2024 | Add a showcase link attribute to open a link in new tab
#### New
-  Now you can specify the way a link from the showcase should be opened.  Use the newTab attribute, like shown below
    ```xml
      <linksShowcase>
            <link url="http://multifactor.ru" title="multifactor" image="logo.svg" newTab="false"/>
      </linksShowcase>
    ```
    By default, a link would be opened in a new tab.