### PR TITLE
feature/dev-340-355

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web.Configuration;
+using MultiFactor.SelfService.Windows.Portal.Core;
 using MultiFactor.SelfService.Windows.Portal.Models;
 
 namespace MultiFactor.SelfService.Windows.Portal
@@ -141,6 +142,8 @@ namespace MultiFactor.SelfService.Windows.Portal
         public long? PwdChangingSessionCacheSize { get; private set; }
         public Link[] Links { get; private set; }
         public int NotifyOnPasswordExpirationDaysLeft { get; private set; }
+        
+        public PrivacyModeDescriptor PrivacyModeDescriptor { get; private set; }
 
         public static void Load()
         {
@@ -169,7 +172,7 @@ namespace MultiFactor.SelfService.Windows.Portal
             var enableExchangeActiveSyncServicesManagementSetting = ParseBoolean(appSettings, ConfigurationConstants.General.ENABLE_EXCHANGE_ACTIVE_SYNC_DEVICES_MANAGEMENT);
             var useUpnAsIdentitySetting = ParseBoolean(appSettings, ConfigurationConstants.General.USE_UPN_AS_IDENTITY);
             var notifyPasswordExpirationDaysLeft = ReadNotifyPasswordExpirationDaysLeft(appSettings);
-
+            var privacyMode = GetValue(appSettings, ConfigurationConstants.General.PrivacyMode);
 
             var configuration = new Configuration
             {
@@ -189,6 +192,7 @@ namespace MultiFactor.SelfService.Windows.Portal
                 UseUpnAsIdentity = useUpnAsIdentitySetting,
                 NotifyOnPasswordExpirationDaysLeft = notifyPasswordExpirationDaysLeft,
                 PreAuthnMode = preAuthnMode,
+                PrivacyModeDescriptor = PrivacyModeDescriptor.Create(privacyMode)
             };
             
             if (!string.IsNullOrEmpty(activeDirectory2FaGroupSetting))

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -30,6 +30,15 @@ namespace MultiFactor.SelfService.Windows.Portal
         /// Only members of these groups required to pass 2fa to access (Optional)
         /// </summary>
         public string[] ActiveDirectory2FaGroup { get; private set; } = Array.Empty<string>();
+        
+        /// <summary>
+        /// Only members of these groups have access to the resource (Optional)
+        /// </summary>
+        public string[] ActiveDirectoryGroup { get; private set; } = Array.Empty<string>();
+
+        public bool LoadActiveDirectoryNestedGroups { get; private set; } = true;
+        
+        public string[] NestedGroupsBaseDn { get; private set; } = Array.Empty<string>();
 
         /// <summary>
         /// Use ActiveDirectory User general properties phone number (Optional)
@@ -174,6 +183,11 @@ namespace MultiFactor.SelfService.Windows.Portal
             var notifyPasswordExpirationDaysLeft = ReadNotifyPasswordExpirationDaysLeft(appSettings);
             var privacyMode = GetValue(appSettings, ConfigurationConstants.General.PrivacyMode);
 
+
+            var loadActiveDirectoryNestedGroups = ParseBoolean(appSettings, ConfigurationConstants.General.LOAD_AD_NESTED_GROUPS);
+            var activeDirectoryGroupSetting = GetValue(appSettings, ConfigurationConstants.General.ACTIVE_DIRECTORY_GROUP);
+            var nestedGroupsBaseDn = GetValue(appSettings, ConfigurationConstants.General.NESTED_GROUPS_BASE_DN);
+            
             var configuration = new Configuration
             {
                 CompanyName = companyNameSetting,
@@ -192,13 +206,34 @@ namespace MultiFactor.SelfService.Windows.Portal
                 UseUpnAsIdentity = useUpnAsIdentitySetting,
                 NotifyOnPasswordExpirationDaysLeft = notifyPasswordExpirationDaysLeft,
                 PreAuthnMode = preAuthnMode,
+                LoadActiveDirectoryNestedGroups = loadActiveDirectoryNestedGroups,
                 PrivacyModeDescriptor = PrivacyModeDescriptor.Create(privacyMode)
             };
             
             if (!string.IsNullOrEmpty(activeDirectory2FaGroupSetting))
             {
-                configuration.ActiveDirectory2FaGroup = activeDirectory2FaGroupSetting.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToArray();
+                configuration.ActiveDirectory2FaGroup = activeDirectory2FaGroupSetting
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Distinct()
+                    .ToArray();
             }
+            
+            if (!string.IsNullOrEmpty(nestedGroupsBaseDn))
+            {
+                configuration.NestedGroupsBaseDn = nestedGroupsBaseDn
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+
+            if (!string.IsNullOrEmpty(activeDirectoryGroupSetting))
+            {
+                configuration.ActiveDirectoryGroup = activeDirectoryGroupSetting
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Distinct()
+                    .ToArray();
+            }
+
             var activeDirectorySection = (ActiveDirectorySection)ConfigurationManager.GetSection("ActiveDirectory");
             if (activeDirectorySection != null)
             {

--- a/Constants.cs
+++ b/Constants.cs
@@ -36,6 +36,9 @@ namespace MultiFactor.SelfService.Windows.Portal
                 public const string NOTIFY_PASSWORD_EXPIRATION_DAYS_LEFT = "notify-on-password-expiration-days-left";
                 public const string PRE_AUTHN_MODE = "pre-authentication-method";
                 public const string PrivacyMode = "privacy-mode";
+                public const string LOAD_AD_NESTED_GROUPS = "load-active-directory-nested-groups";
+                public const string ACTIVE_DIRECTORY_GROUP = "active-directory-group";
+                public const string NESTED_GROUPS_BASE_DN = "nested-groups-base-dn";
             }
 
             public static class ObsoleteCaptcha

--- a/Constants.cs
+++ b/Constants.cs
@@ -35,6 +35,7 @@ namespace MultiFactor.SelfService.Windows.Portal
                 public const string LOGGING_FORMAT = "logging-format";
                 public const string NOTIFY_PASSWORD_EXPIRATION_DAYS_LEFT = "notify-on-password-expiration-days-left";
                 public const string PRE_AUTHN_MODE = "pre-authentication-method";
+                public const string PrivacyMode = "privacy-mode";
             }
 
             public static class ObsoleteCaptcha

--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -430,11 +430,18 @@ namespace MultiFactor.SelfService.Windows.Portal.Controllers
                     validationResult.PasswordExpirationDate.ToString());
             }
 
-            var accessPage = _apiClient.CreateAccessRequest(login,
+            var personalData = new PersonalData(
                 validationResult?.DisplayName,
                 validationResult?.Email,
                 validationResult?.Phone,
-                postbackUrl, claims);
+                Configuration.Current.PrivacyModeDescriptor);
+            
+            var accessPage = _apiClient.CreateAccessRequest(login,
+                personalData.Name,
+                personalData.Email,
+                personalData.Phone,
+                postbackUrl,
+                claims);
 
             return RedirectPermanent(accessPage.Url);
         }

--- a/Core/PrivacyMode.cs
+++ b/Core/PrivacyMode.cs
@@ -1,0 +1,23 @@
+namespace MultiFactor.SelfService.Windows.Portal.Core
+{
+    /// <summary>
+    /// User information disclosure mode
+    /// </summary>
+    public enum PrivacyMode
+    {
+        /// <summary>
+        /// Include all
+        /// </summary>
+        None,
+    
+        /// <summary>
+        /// Disable all but identity
+        /// </summary>
+        Full,
+
+        /// <summary>
+        /// Disable all but identity and specified fields.
+        /// </summary>
+        Partial
+    }
+}

--- a/Core/PrivacyModeDescriptor.cs
+++ b/Core/PrivacyModeDescriptor.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+
+namespace MultiFactor.SelfService.Windows.Portal.Core
+{
+    public class PrivacyModeDescriptor
+    {
+        private readonly string[] _fields;
+        public PrivacyMode Mode { get; }
+
+        public static PrivacyModeDescriptor Default => new PrivacyModeDescriptor(PrivacyMode.None);
+
+        public bool HasField(string field)
+        {
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                return false;
+            }
+
+            return _fields.Any(x => x.Equals(field, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private PrivacyModeDescriptor(PrivacyMode mode, params string[] fields)
+        {
+            Mode = mode;
+            _fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        }
+
+        public static PrivacyModeDescriptor Create(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return new PrivacyModeDescriptor(PrivacyMode.None);
+
+            var mode = GetMode(value);
+            if (mode != PrivacyMode.Partial) return new PrivacyModeDescriptor(mode);
+
+            var fields = GetFields(value);
+            return new PrivacyModeDescriptor(mode, fields);
+        }
+
+        private static PrivacyMode GetMode(string value)
+        {
+            var index = value.IndexOf(':');
+            if (index == -1)
+            {
+                if (!Enum.TryParse<PrivacyMode>(value, true, out var parsed1))
+                    throw new Exception("Unexpected privacy-mode value");
+                return parsed1;
+            }
+
+            var sub = value.Substring(0, index);
+            if (!Enum.TryParse<PrivacyMode>(sub, true, out var parsed2))
+                throw new Exception("Unexpected privacy-mode value");
+
+            return parsed2;
+        }
+
+        private static string[] GetFields(string value)
+        {
+            var index = value.IndexOf(':');
+            if (index == -1 || value.Length <= index + 1)
+            {
+                return Array.Empty<string>();
+            }
+
+            var sub = value.Substring(index + 1, value.Length - index - 1);
+            return sub.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Distinct().ToArray();
+        }
+    }
+}

--- a/Models/PersonalData.cs
+++ b/Models/PersonalData.cs
@@ -1,0 +1,42 @@
+using MultiFactor.SelfService.Windows.Portal.Core;
+
+namespace MultiFactor.SelfService.Windows.Portal.Models
+{
+    public class PersonalData
+    {
+        public string Name { get; private set; }
+        public string Email { get; private set; }
+        public string Phone { get; private set; }
+
+        public PersonalData(string name, string email, string phone, PrivacyModeDescriptor privacyModeDescriptor)
+        {
+            (Name, Email, Phone) = (name, email, phone);
+        
+            switch (privacyModeDescriptor.Mode)
+            {
+                case PrivacyMode.Full:
+                    Name = null;
+                    Email = null;
+                    Phone = null;
+                    break;
+            
+                case PrivacyMode.Partial:
+                    if (!privacyModeDescriptor.HasField("Name"))
+                    {
+                        Name = null;
+                    }
+
+                    if (!privacyModeDescriptor.HasField("Email"))
+                    {
+                        Email = null;
+                    }
+
+                    if (!privacyModeDescriptor.HasField("Phone"))
+                    {
+                        Phone = null;
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/MultiFactor.SelfService.Windows.Portal.csproj
+++ b/MultiFactor.SelfService.Windows.Portal.csproj
@@ -271,6 +271,8 @@
     <Compile Include="Core\Http\GoogleCaptchaHttpClientAdapterFactory.cs" />
     <Compile Include="Core\Http\HttpClientUtils.cs" />
     <Compile Include="Core\Http\NewtonsoftJsonDataSerializer.cs" />
+    <Compile Include="Core\PrivacyMode.cs" />
+    <Compile Include="Core\PrivacyModeDescriptor.cs" />
     <Compile Include="Core\SerializingSettings.cs" />
     <Compile Include="Core\CustomDependencyResolver.cs" />
     <Compile Include="Extensions\SearchResponseExtensions.cs" />
@@ -297,6 +299,7 @@
     <Compile Include="Models\LoginModel.cs" />
     <Compile Include="Models\PasswordRecovery\ConfirmPasswordRecoveryForm.cs" />
     <Compile Include="Models\PasswordRecovery\EnterIdentityForm.cs" />
+    <Compile Include="Models\PersonalData.cs" />
     <Compile Include="Models\SingleSignOnDto.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Shared_PasswordRequirementsPartial.ru.Designer.cs">

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,4 +1,7 @@
-﻿<!DOCTYPE html>
+﻿@{
+    ViewBag.Title = string.Format(Resources.Global.SiteName, Configuration.Current.CompanyName);
+}
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
@@ -9,7 +12,7 @@
     @Scripts.Render("~/bundles/jqueryval")
     @Scripts.Render("~/bundles/jquery.validate.unobtrusive")
     @RenderSection("head", false)
-    <title>@ViewBag.Title</title>
+    <title>ViewBag.Title</title>
 </head>
 <body>
     <div id="wrapper">


### PR DESCRIPTION
## Release  21.01.2025 | Privacy mode

#### New
1. Added `privacy-mode` setting. You can use two modes:
- `Full` mode - remove Name, Email, Phone from MF API request.
- `Partial` mode - only marked fields are sent in the MF API request.

	Examples
	```
	Full mode
	<add key="privacy-mode" value="Full"/>
	```
	```
	Send only Name
	<add key="privacy-mode" value="Partial:Name"/>
	```
	```
	Send Email and Phone
	<add key="privacy-mode" value="Partial:Email,Phone"/>
	```
2. Added the `load-active-directory-nested-groups` setting. The setting is responsible for loading nested groups when loading a user profile.
	```
	 <add key="load-active-directory-nested-groups" value="true/false"/>
	```
3. Added the `nested-groups-base-dn` setting. The setting specifies where to start searching for nested user groups. By default domain root is used. Multiple DNs can be specified via `;`
	```
	 <add key="nested-groups-base-dn" value="CN=users,DC=domain,DC=your"/>
	```
4. Added the `active-directory-group` setting. The setting specifies the groups the user must be in to pass the first factor. Multiple groups can be specified via `;`
	```
	<add key="active-directory-group" value="required_group_1;required_group_2"/>
	```